### PR TITLE
Fix tap-jira IndexError on empty issues page

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -600,6 +600,9 @@ class Issues(Stream):
         for page in pager.pages(
             self.tap_stream_id, "GET", "/rest/api/3/search/jql", params=params
         ):
+            if not page:
+                LOGGER.warning("Received empty page from issues search, skipping")
+                continue
             # sync comments and changelogs for each issue
             sync_sub_streams(page)
             for issue in page:


### PR DESCRIPTION
## Summary
- Guard against empty pages returned by the Jira search API during cursor-based pagination in `Issues.sync()`
- When `page` is an empty list, `page[-1]["fields"]["updated"]` crashes with `IndexError: list index out of range`
- Added an early `continue` with a warning log to skip empty pages entirely

## Test plan
- [ ] Run existing test suite: `python -m pytest tests/`
- [ ] Test with a state file targeting a date range returning 0 issues to confirm no crash
- [ ] Verify normal pagination with non-empty pages still works correctly

Generated with [Claude Code](https://claude.com/claude-code)