### PR TITLE
Hotfix: add support for service account API token

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -291,9 +291,7 @@ class Client():
             self.login_timer.start()
 
     def test_credentials_are_authorized(self):
-        # Assume that everyone has issues, so we try and hit that endpoint
-        self.request("issues", "GET", "/rest/api/2/search",
-                     params={"maxResults": 1})
+        self.request("issues", "GET", "/rest/api/3/myself")
 
     def test_basic_credentials_are_authorized(self):
         # Make a call to myself endpoint for verify creds


### PR DESCRIPTION
## Summary
- Atlassian removed `/rest/api/2/search` (returns 410), which broke `Client.__init__` for cloud-mode runs that use a service-account API token sent as a Bearer token against `api.atlassian.com`.
- Swap the cloud-mode credential probe in `test_credentials_are_authorized` to `/rest/api/3/myself` — the canonical "is this token valid" endpoint, which works for OAuth and scoped service-account tokens alike.
- The Issues stream itself already uses `/rest/api/3/search/jql`; only the constructor-time probe was stale.

## Test plan
- [ ] Re-run the servicecore tap-jira DAG; confirm logs show `INFO Using OAuth based API authentication` followed by a 200 from `myself` (no 410, no traceback at construction time).
- [ ] Confirm discovery proceeds and the sync starts streaming records past the constructor.
- [ ] Smoke-test on an existing OAuth-3LO Jira Cloud customer to confirm the probe still passes for them (no regression in the cloud branch).
- [ ] Confirm Basic Auth / on-prem customers are unaffected (this change only touches `test_credentials_are_authorized`, not `test_basic_credentials_are_authorized`).

Generated with [Claude Code](https://claude.com/claude-code)